### PR TITLE
feat: 背景模糊与放假提示

### DIFF
--- a/renderer.c
+++ b/renderer.c
@@ -4,16 +4,137 @@
 #include <windows.h>
 #include <shellapi.h>
 #include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define BLUR_RADIUS_PIXELS      6
+#define BLUR_BACKGROUND_ALPHA   230
 
 extern ClassInfo timetable[DAYS][CLASSES];
 
 static BOOL g_currentFrameHasOverflow = FALSE;
 static BOOL g_lastFrameHasOverflow = FALSE;
+static BOOL g_blurEnabled = TRUE;
+static BYTE *g_blurScratch = NULL;
+static size_t g_blurScratchSize = 0;
+static BYTE *g_backgroundSnapshot = NULL;
+static size_t g_backgroundSnapshotSize = 0;
 
 static void UpdateOverflowFlag(BOOL overflowed) {
     if (overflowed) {
         g_currentFrameHasOverflow = TRUE;
     }
+}
+
+void RendererSetBlurEnabled(BOOL enabled) {
+    g_blurEnabled = enabled ? TRUE : FALSE;
+}
+
+BOOL RendererIsBlurEnabled(void) {
+    return g_blurEnabled;
+}
+
+static BOOL EnsureBufferCapacity(BYTE **buffer, size_t *capacity, size_t required) {
+    if (!buffer || !capacity) {
+        return FALSE;
+    }
+    if (*capacity >= required) {
+        return TRUE;
+    }
+    BYTE *newBuffer = (BYTE*)realloc(*buffer, required);
+    if (!newBuffer) {
+        return FALSE;
+    }
+    *buffer = newBuffer;
+    *capacity = required;
+    return TRUE;
+}
+
+static int ClampInt(int value, int minValue, int maxValue) {
+    if (value < minValue) return minValue;
+    if (value > maxValue) return maxValue;
+    return value;
+}
+
+static void BoxBlurHorizontal(const BYTE *src, BYTE *dst, int width, int height, int stride, int radius) {
+    int kernelSize = radius * 2 + 1;
+    for (int y = 0; y < height; ++y) {
+        const BYTE *row = src + y * stride;
+        BYTE *outRow = dst + y * stride;
+        int sumB = 0, sumG = 0, sumR = 0;
+        for (int ix = -radius; ix <= radius; ++ix) {
+            int cx = ClampInt(ix, 0, width - 1);
+            const BYTE *p = row + cx * 4;
+            sumB += p[0];
+            sumG += p[1];
+            sumR += p[2];
+        }
+        for (int x = 0; x < width; ++x) {
+            BYTE *dstPx = outRow + x * 4;
+            dstPx[0] = (BYTE)(sumB / kernelSize);
+            dstPx[1] = (BYTE)(sumG / kernelSize);
+            dstPx[2] = (BYTE)(sumR / kernelSize);
+            dstPx[3] = 255;
+
+            int oldIndex = x - radius;
+            int newIndex = x + radius + 1;
+            int oldClamped = ClampInt(oldIndex, 0, width - 1);
+            int newClamped = ClampInt(newIndex, 0, width - 1);
+            const BYTE *oldPx = row + oldClamped * 4;
+            const BYTE *newPx = row + newClamped * 4;
+            sumB += newPx[0] - oldPx[0];
+            sumG += newPx[1] - oldPx[1];
+            sumR += newPx[2] - oldPx[2];
+        }
+    }
+}
+
+static void BoxBlurVertical(const BYTE *src, BYTE *dst, int width, int height, int stride, int radius) {
+    int kernelSize = radius * 2 + 1;
+    for (int x = 0; x < width; ++x) {
+        int sumB = 0, sumG = 0, sumR = 0;
+        for (int iy = -radius; iy <= radius; ++iy) {
+            int cy = ClampInt(iy, 0, height - 1);
+            const BYTE *p = src + cy * stride + x * 4;
+            sumB += p[0];
+            sumG += p[1];
+            sumR += p[2];
+        }
+        for (int y = 0; y < height; ++y) {
+            BYTE *dstPx = dst + y * stride + x * 4;
+            dstPx[0] = (BYTE)(sumB / kernelSize);
+            dstPx[1] = (BYTE)(sumG / kernelSize);
+            dstPx[2] = (BYTE)(sumR / kernelSize);
+            dstPx[3] = 255;
+
+            int oldIndex = y - radius;
+            int newIndex = y + radius + 1;
+            int oldClamped = ClampInt(oldIndex, 0, height - 1);
+            int newClamped = ClampInt(newIndex, 0, height - 1);
+            const BYTE *oldPx = src + oldClamped * stride + x * 4;
+            const BYTE *newPx = src + newClamped * stride + x * 4;
+            sumB += newPx[0] - oldPx[0];
+            sumG += newPx[1] - oldPx[1];
+            sumR += newPx[2] - oldPx[2];
+        }
+    }
+}
+
+static BOOL ApplyBoxBlur(BYTE *pixels, int width, int height, int stride, int radius) {
+    if (!pixels || width <= 0 || height <= 0) {
+        return FALSE;
+    }
+    if (radius <= 0) {
+        return TRUE;
+    }
+    size_t required = (size_t)stride * (size_t)height;
+    if (!EnsureBufferCapacity(&g_blurScratch, &g_blurScratchSize, required)) {
+        return FALSE;
+    }
+    BYTE *temp = g_blurScratch;
+    BoxBlurHorizontal(pixels, temp, width, height, stride, radius);
+    BoxBlurVertical(temp, pixels, width, height, stride, radius);
+    return TRUE;
 }
 
 static double ClampDouble(double value, double minValue, double maxValue) {
@@ -125,22 +246,66 @@ void DrawTimetable(HDC hdc, RECT rc, int viewMode) {
     if (viewMode == 0) {
         // ==== 日视图 ====
         int cellH = (rc.bottom - rc.top) / CLASSES;
+        BOOL hasCourse = FALSE;
+        for (int i=0; i<CLASSES; i++) {
+            if ((timetable[today][i].name && timetable[today][i].name[0] != L'\0') ||
+                (timetable[today][i].location && timetable[today][i].location[0] != L'\0')) {
+                hasCourse = TRUE;
+                break;
+            }
+        }
+
         for (int i=0; i<CLASSES; i++) {
             MoveToEx(hdc, rc.left, rc.top + i*cellH, NULL);
             LineTo(hdc, rc.right, rc.top + i*cellH);
 
             RECT cellRect = {rc.left, rc.top + i*cellH, rc.right, rc.top + (i+1)*cellH};
-            
-            if (timetable[today][i].name) {
+
+            if (hasCourse && timetable[today][i].name) {
                 // 绘制课程名称（居中显示）
                 DrawTextCentered(hdc, &cellRect, timetable[today][i].name, 10);
-                
+
                 // 绘制位置信息（居中显示）
                 if (timetable[today][i].location) {
                     SetTextColor(hdc, RGB(200, 200, 200)); // 稍微淡一点的颜色
                     DrawTextCentered(hdc, &cellRect, timetable[today][i].location, 35);
                     SetTextColor(hdc, RGB(255,255,255)); // 恢复白色
                 }
+            }
+        }
+
+        if (!hasCourse) {
+            LOGFONT lfHoliday = lf;
+            lfHoliday.lfHeight = -MulDiv(28, dpi, 96);
+            HFONT hHoliday = CreateFontIndirect(&lfHoliday);
+            HFONT oldHoliday = NULL;
+            if (hHoliday) {
+                oldHoliday = (HFONT)SelectObject(hdc, hHoliday);
+            }
+
+            const WCHAR holidayText[] = L"放假";
+            int charCount = (int)lstrlenW(holidayText);
+            TEXTMETRIC tmHoliday;
+            GetTextMetrics(hdc, &tmHoliday);
+            int charSpacing = MulDiv(6, dpi, 96);
+            int totalHeight = charCount * tmHoliday.tmHeight + (charCount - 1) * charSpacing;
+            int startY = rc.top + ((rc.bottom - rc.top) - totalHeight) / 2;
+            int centerX = rc.left + (rc.right - rc.left) / 2;
+
+            for (int i = 0; i < charCount; ++i) {
+                WCHAR ch[2] = { holidayText[i], L'\0' };
+                SIZE chSize = {0};
+                GetTextExtentPoint32W(hdc, ch, 1, &chSize);
+                int x = centerX - chSize.cx / 2;
+                int y = startY + i * (tmHoliday.tmHeight + charSpacing);
+                TextOutW(hdc, x, y, ch, 1);
+            }
+
+            if (hHoliday && oldHoliday) {
+                SelectObject(hdc, oldHoliday);
+            }
+            if (hHoliday) {
+                DeleteObject(hHoliday);
             }
         }
     } else {
@@ -212,37 +377,65 @@ void RenderLayered(HWND hwnd, int viewMode) {
         return;
     }
 
-    // 背景颜色和 alpha（基准 alpha）
-    BYTE bgR = 0, bgG = 0, bgB = 0;  // 改为黑色背景
-    BYTE baseAlpha = (BYTE)WINDOW_ALPHA;
+    int stride = width * 4;
+    size_t bufferSize = (size_t)stride * (size_t)height;
+    BOOL blurActive = g_blurEnabled ? TRUE : FALSE;
+    BYTE baseAlpha = blurActive ? (BYTE)BLUR_BACKGROUND_ALPHA : (BYTE)WINDOW_ALPHA;
+    BYTE *pixelData = (BYTE*)pvBits;
 
-    // 先把缓冲区设置为不透明的背景预乘色（用 baseAlpha），后续会根据圆角蒙版重新赋值
-    UINT pixels = width * height;
-    BYTE *ptr = (BYTE*)pvBits;
-    BYTE bgRp_base = (BYTE)((bgR * baseAlpha) / 255);
-    BYTE bgGp_base = (BYTE)((bgG * baseAlpha) / 255);
-    BYTE bgBp_base = (BYTE)((bgB * baseAlpha) / 255);
-    for (UINT i = 0; i < pixels; ++i) {
-        ptr[0] = bgBp_base; // B
-        ptr[1] = bgGp_base; // G
-        ptr[2] = bgRp_base; // R
-        ptr[3] = baseAlpha; // A
-        ptr += 4;
-    }
-
-    // 在 DIB 的 DC 上绘制文字（GDI 不会修改 alpha 字节）
     HDC hdcScreen = GetDC(NULL);
     HDC memDC = CreateCompatibleDC(hdcScreen);
     HBITMAP oldBmp = (HBITMAP)SelectObject(memDC, hBitmap);
 
+    RECT wndRect;
+    GetWindowRect(hwnd, &wndRect);
+
+    if (blurActive) {
+        BitBlt(memDC, 0, 0, width, height, hdcScreen, wndRect.left, wndRect.top, SRCCOPY);
+        for (size_t i = 0; i < bufferSize; i += 4) {
+            pixelData[i + 3] = 255;
+        }
+        if (!ApplyBoxBlur(pixelData, width, height, stride, BLUR_RADIUS_PIXELS)) {
+            blurActive = FALSE;
+            baseAlpha = (BYTE)WINDOW_ALPHA;
+        }
+    }
+
+    if (!blurActive) {
+        for (size_t i = 0; i < bufferSize; i += 4) {
+            pixelData[i + 0] = 0;
+            pixelData[i + 1] = 0;
+            pixelData[i + 2] = 0;
+            pixelData[i + 3] = 255;
+        }
+    }
+
+    BYTE *backgroundPtr = NULL;
+    if (EnsureBufferCapacity(&g_backgroundSnapshot, &g_backgroundSnapshotSize, bufferSize)) {
+        backgroundPtr = g_backgroundSnapshot;
+        memcpy(backgroundPtr, pixelData, bufferSize);
+    } else if (blurActive) {
+        // 内存不足时退回到半透明背景
+        blurActive = FALSE;
+        baseAlpha = (BYTE)WINDOW_ALPHA;
+        for (size_t i = 0; i < bufferSize; i += 4) {
+            pixelData[i + 0] = 0;
+            pixelData[i + 1] = 0;
+            pixelData[i + 2] = 0;
+            pixelData[i + 3] = 255;
+        }
+        if (EnsureBufferCapacity(&g_backgroundSnapshot, &g_backgroundSnapshotSize, bufferSize)) {
+            backgroundPtr = g_backgroundSnapshot;
+            memcpy(backgroundPtr, pixelData, bufferSize);
+        }
+    }
+
     DrawTimetable(memDC, rc, viewMode);
 
-    // 遍历像素：为圆角计算平滑遮罩；背景像素按遮罩设为预乘色，文本像素保持不透明
-    // 使用像素中心 (x+0.5, y+0.5) 计算距离平方并在平方域内线性插值（避免 sqrt）
-    ptr = (BYTE*)pvBits;
+    BYTE *ptr = pixelData;
+    const BYTE *bgPtr = backgroundPtr;
     for (int y = 0; y < height; ++y) {
         for (int x = 0; x < width; ++x) {
-            BYTE b = ptr[0], g = ptr[1], r = ptr[2];
             float cx = x + 0.5f;
             float cy = y + 0.5f;
             float mask = 1.0f;
@@ -265,30 +458,36 @@ void RenderLayered(HWND hwnd, int viewMode) {
                 } else if (dist2 >= rPlus2) {
                     mask = 0.0f;
                 } else {
-                    // 在平方域内线性插值（避免调用 sqrt）
                     mask = (rPlus2 - dist2) / (rPlus2 - rMinus2);
                     if (mask < 0.0f) mask = 0.0f;
                     if (mask > 1.0f) mask = 1.0f;
                 }
-            } else {
-                mask = 1.0f;
             }
 
-            BYTE maskAlpha = (BYTE)(baseAlpha * mask + 0.5f);
-
-            // 判断是否为背景像素（与基准预乘色比较）
-            if (b == bgBp_base && g == bgGp_base && r == bgRp_base) {
-                // 背景像素：按 maskAlpha 重新计算预乘颜色与 alpha
-                ptr[3] = maskAlpha;
-                ptr[2] = (BYTE)((bgR * (int)maskAlpha) / 255); // R
-                ptr[1] = (BYTE)((bgG * (int)maskAlpha) / 255); // G
-                ptr[0] = (BYTE)((bgB * (int)maskAlpha) / 255); // B
-            } else {
-                // 非背景（认为是文本或其他绘制），保持不透明
-                ptr[3] = 255;
+            BYTE cornerMask = (BYTE)(mask * 255.0f + 0.5f);
+            BOOL isBackgroundPixel = FALSE;
+            if (bgPtr) {
+                isBackgroundPixel = (ptr[0] == bgPtr[0] && ptr[1] == bgPtr[1] && ptr[2] == bgPtr[2]);
+            } else if (!blurActive) {
+                isBackgroundPixel = (ptr[0] == 0 && ptr[1] == 0 && ptr[2] == 0);
             }
+
+            BYTE finalAlpha;
+            if (isBackgroundPixel) {
+                finalAlpha = (BYTE)(((int)baseAlpha * cornerMask) / 255);
+            } else {
+                finalAlpha = cornerMask;
+            }
+
+            ptr[3] = finalAlpha;
+            ptr[0] = (BYTE)((ptr[0] * (int)finalAlpha) / 255);
+            ptr[1] = (BYTE)((ptr[1] * (int)finalAlpha) / 255);
+            ptr[2] = (BYTE)((ptr[2] * (int)finalAlpha) / 255);
 
             ptr += 4;
+            if (bgPtr) {
+                bgPtr += 4;
+            }
         }
     }
 

--- a/renderer.h
+++ b/renderer.h
@@ -18,4 +18,8 @@ void DrawTextCentered(HDC hdc, RECT* rc, WCHAR* text, int yOffset);
 // 当前渲染是否存在需要滚动显示的文本
 BOOL RendererHasOverflowingText(void);
 
+// 控制背景模糊开关
+void RendererSetBlurEnabled(BOOL enabled);
+BOOL RendererIsBlurEnabled(void);
+
 #endif // RENDERER_H

--- a/timetable.c
+++ b/timetable.c
@@ -18,6 +18,7 @@
 #define ID_TRAY_EXIT     1002
 #define ID_TRAY_SWITCH   1003
 #define ID_TRAY_BOTTOM   1004
+#define ID_TRAY_BLUR     1005
 #define WM_SYSICON       (WM_USER + 1)
 #define SNAP_DIST        20
 #define SNAP_MARGIN      10
@@ -300,6 +301,8 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
                        viewMode==0 ? L"切换到周视图" : L"切换到日视图");
             AppendMenu(hMenu, MF_STRING | (keepOnBottom ? MF_CHECKED : MF_UNCHECKED),
                        ID_TRAY_BOTTOM, L"窗口总在底层");
+            AppendMenu(hMenu, MF_STRING | (RendererIsBlurEnabled() ? MF_CHECKED : MF_UNCHECKED),
+                       ID_TRAY_BLUR, L"背景模糊");
             AppendMenu(hMenu, MF_STRING, ID_TRAY_EXIT, L"退出");
             POINT pt;
             GetCursorPos(&pt);
@@ -319,6 +322,10 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
             if (keepOnBottom) {
                 EnsureBottomOrder(hwnd);
             }
+        } else if (LOWORD(wParam) == ID_TRAY_BLUR) {
+            BOOL newState = !RendererIsBlurEnabled();
+            RendererSetBlurEnabled(newState);
+            RenderLayered(hwnd, viewMode);
         } else if (LOWORD(wParam) == ID_TRAY_SWITCH) {
             viewMode = 1 - viewMode; // 切换模式
 


### PR DESCRIPTION
## Summary
- add a small-radius box blur pipeline with reusable buffers so the layered window can render either a blurred backdrop or the existing translucent fill, while preserving rounded corners
- expose blur toggles through the renderer header and tray menu so the blur is enabled by default but can be switched off at runtime
- show a vertically centered “放假” banner on days with no classes in the day view

## Testing
- ./compile.bat *(fails in this Linux container because Windows batch files are not executable)*

------
https://chatgpt.com/codex/tasks/task_e_68ce58009d10832c9764e7b47ea0e7ec